### PR TITLE
Fix fontspec's font-not-found error on XeLaTeX

### DIFF
--- a/templates/fontawesome.sty.template
+++ b/templates/fontawesome.sty.template
@@ -42,7 +42,7 @@
 \usepackage{fontspec}
 
 % definition of \FA as a shortcut to load the Font Awesome font
-\newfontfamily{\FA}{FontAwesome}
+\newfontfamily{\FA}{FontAwesome}[Extension=.otf]
 
 % icon-specific commands
 \input{fontawesomesymbols-xeluatex.tex}


### PR DESCRIPTION
__TL;DR__: XeTeX cannot load fonts in TEXMF tree by their font name whereas LuaTeX can. Therefore we need to specify FontAwesome by file name so that both XeTeX and LuaTeX can load it.

---

Consider the following MWE:

```latex
\documentclass{article}
\usepackage{fontawesome}
\begin{document}
\faAdjust
\end{document}
```

While this MWE works with LuaLaTeX, it doesn't with XeLaTeX issuing the following error:

```console
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!
! fontspec error: "font-not-found"
!
! The font "FontAwesome" cannot be found.
!
! See the fontspec documentation for further information.
!
! For immediate help type H <return>.
!...............................................

l.45 \newfontfamily{\FA}{FontAwesome}
```

The reason for this pretty easy; it's clearly described in the fontspec documentation. Here is an excerpt from section 5.2 of v2.6d:

> Fonts in such locations are visible to XeTeX but cannot be loaded by font name, only file name; LuaTeX does not have this restriction.

There are several ways to load fonts by file name, and I specified the extension `.otf` in the optional argument because this is convenient when we load bold and italic variants of a font (FontAwesome doesn't have variants, though).

Fix #12.